### PR TITLE
fix list of paired bridges when auto-discovery is not available

### DIFF
--- a/Sources/com.elgato.philips-hue.sdPlugin/pi/js/pi.js
+++ b/Sources/com.elgato.philips-hue.sdPlugin/pi/js/pi.js
@@ -215,7 +215,11 @@ function PI(inContext, inLanguage, inStreamDeckVersion, inPluginVersion) {
         }
 
         // Add new bridge to the global settings
-        globalSettings.bridges[inEvent.detail.id] = { 'username': inEvent.detail.username };
+        globalSettings.bridges[inEvent.detail.id] = {
+            ip: inEvent.detail.ip,
+            id: inEvent.detail.id,
+            username: inEvent.detail.username,
+        };
         saveGlobalSettings(inContext);
     }
 

--- a/Sources/com.elgato.philips-hue.sdPlugin/plugin/js/philips/meethue.js
+++ b/Sources/com.elgato.philips-hue.sdPlugin/plugin/js/philips/meethue.js
@@ -244,6 +244,38 @@ Bridge.discover = function(callback) {
     xhr.send();
 };
 
+// Check if a Bridge is available under a certain IP address
+// If a username is set it will check that too
+Bridge.check = function(ip, username, callback) {
+    let url = username ? `http://${ip}/api/${username}config` : `http://${ip}/api/config`;
+    let xhr = new XMLHttpRequest();
+    xhr.responseType = 'json';
+    xhr.open('GET', url, true);
+    xhr.timeout = 10000;
+
+    xhr.onload = function() {
+        if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200 &&
+            xhr.response !== undefined && xhr.response != null &&
+            xhr.response.hasOwnProperty('bridgeid') &&
+            (!username || xhr.response.hasOwnProperty('ipaddress'))
+        ) {
+            // at this point the bridge has been found and added to list
+            callback(true, {
+                ip: ip,
+                id: xhr.response.bridgeid.toLowerCase(),
+            });
+        }
+
+        callback(false);
+    };
+
+    xhr.onerror = xhr.ontimeout = function() {
+        callback(false);
+    };
+
+    xhr.send();
+};
+
 // Static function to convert hex to rgb
 Bridge.hex2rgb = function(inHex) {
     // Remove hash if it exists

--- a/Sources/com.elgato.philips-hue.sdPlugin/setup/js/manualView.js
+++ b/Sources/com.elgato.philips-hue.sdPlugin/setup/js/manualView.js
@@ -58,35 +58,18 @@ function loadManualView() {
             return;
         }
 
-        // try reaching bridge
-        let url = `http://${ip}/api/config`;
-        let xhr = new XMLHttpRequest();
-        xhr.responseType = 'json';
-        xhr.open('GET', url, true);
-        xhr.timeout = 10000;
-
-        xhr.onload = function() {
-            if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200 &&
-                xhr.response !== undefined && xhr.response != null &&
-                xhr.response.hasOwnProperty('bridgeid')
-            ) {
+        Bridge.check(ip, null, (success, data) => {
+            if (success) {
                 bridges = [
-                    new Bridge(ip, xhr.response.bridgeid.toLowerCase())
+                    new Bridge(data.ip, data.id),
                 ];
 
-                // at this point the bridge has been found and added to list
                 pair();
-                return;
             }
-
-            printError(localization['Manual']['Error']['Unreachable']);
-        };
-
-        xhr.onerror = xhr.ontimeout = function() {
-            printError(localization['Manual']['Error']['Unreachable']);
-        };
-
-        xhr.send();
+            else {
+                printError(localization['Manual']['Error']['Unreachable']);
+            }
+        });
     }
 
     // Open pairing view

--- a/Sources/com.elgato.philips-hue.sdPlugin/setup/js/saveView.js
+++ b/Sources/com.elgato.philips-hue.sdPlugin/setup/js/saveView.js
@@ -26,15 +26,14 @@ function loadSaveView() {
     document.getElementById('close').addEventListener('click', close);
     document.addEventListener('enterPressed', close);
 
-    // Safe the bridge
-    let detail = {
-        'detail': {
-            'id': bridge.getID(),
-            'username': bridge.getUsername()
+    // Save the bridge
+    let event = new CustomEvent('saveBridge', {
+        detail: {
+            ip: bridge.getIP(),
+            id: bridge.getID(),
+            username: bridge.getUsername(),
         }
-    };
-
-    let event = new CustomEvent('saveBridge', detail);
+    });
     window.opener.document.dispatchEvent(event);
 
     // Close this window


### PR DESCRIPTION
When Bridges have been added manually to the list, but auto-discovery of `meethue` doesn't work, the paired Bridge hasn't been shown in Select list.

In the future the whole process could be much easier, but this would force all user with already paired bridges prior to this update to re-pair their bridges. So for now it's a bit more complicated but is fully backwards compatible.