### PR TITLE
Fixed PI & object cache update for relative brightness

### DIFF
--- a/Sources/com.elgato.philips-hue.sdPlugin/pi/index.html
+++ b/Sources/com.elgato.philips-hue.sdPlugin/pi/index.html
@@ -1,13 +1,13 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html>
   <head>
     <title>com.elgato.philips-hue.pi</title>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
     <!-- Import style sheets -->
-    <link rel="stylesheet" type="text/css" href="css/sdpi.css">
-    <link rel="stylesheet" type="text/css" href="css/colorPI.css">
-    <link rel="stylesheet" type="text/css" href="css/cyclePI.css">
-    <link rel="stylesheet" type="text/css" href="css/pi.css">
+    <link rel="stylesheet" type="text/css" href="css/sdpi.css" />
+    <link rel="stylesheet" type="text/css" href="css/colorPI.css" />
+    <link rel="stylesheet" type="text/css" href="css/cyclePI.css" />
+    <link rel="stylesheet" type="text/css" href="css/pi.css" />
     <!-- Import scripts -->
     <script src="../plugin/js/utils.js"></script>
     <script src="../plugin/js/philips/meethue.js"></script>
@@ -17,6 +17,7 @@
     <script src="js/colorPI.js"></script>
     <script src="js/cyclePI.js"></script>
     <script src="js/brightnessPI.js"></script>
+    <script src="js/brightnessRelPI.js"></script>
     <script src="js/scenePI.js"></script>
     <script src="js/main.js"></script>
   </head>
@@ -48,6 +49,6 @@
       <div id="placeholder"></div>
     </div>
     <!-- Floating tooltips element -->
-    <div class="sdpi-info-label hidden" style="top: -1000px;" data-value=""></div>
+    <div class="sdpi-info-label hidden" style="top: -1000px" data-value=""></div>
   </body>
 </html>

--- a/Sources/com.elgato.philips-hue.sdPlugin/pi/js/main.js
+++ b/Sources/com.elgato.philips-hue.sdPlugin/pi/js/main.js
@@ -66,6 +66,9 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
     else if (action === 'com.elgato.philips-hue.scene') {
         pi = new ScenePI(inUUID, language, streamDeckVersion, pluginVersion);
     }
+    else if (action === 'com.elgato.philips-hue.brightness-rel') {
+        pi = new BrightnessRelPI(inUUID, language, streamDeckVersion, pluginVersion);
+    }
 
     websocket.onmessage = msg => {
         // Received message from Stream Deck

--- a/Sources/com.elgato.philips-hue.sdPlugin/plugin/js/brightnessRelAction.js
+++ b/Sources/com.elgato.philips-hue.sdPlugin/plugin/js/brightnessRelAction.js
@@ -111,7 +111,7 @@ function BrightnessRelAction(inContext, inSettings) {
             // Set light or group state
             obj.setBrightness(brightness, (inSuccess, inError) => {
                 if (inSuccess) {
-                    objCache.birghtness = brightness;
+                    objCache.brightness = brightness;
                 }
                 else {
                     log(inError);


### PR DESCRIPTION
The condition to create a Property Inspector for a Relative Brightness action was missing, as well as the script tag to load the PI code; now fixed & confirmed working in Stream Deck.
Also fixed a typo in caching the current brightness after executing brightness-rel.
VSPrettier decided to add some HTML formatting for good measure 😄 