### PR TITLE
Disable xy if colormode is not xy

### DIFF
--- a/Sources/com.elgato.philips-hue.sdPlugin/plugin/js/philips/meethue.js
+++ b/Sources/com.elgato.philips-hue.sdPlugin/plugin/js/philips/meethue.js
@@ -151,10 +151,10 @@ function Bridge(ip = null, id = null, username = null) {
                             let value = result[key];
 
                             if (type === 'light') {
-                                objects.push(new Light(instance, key, value.name, value.type, value.state.on, value.state.bri, value.state.xy, value.state.ct));
+                                objects.push(new Light(instance, key, value.name, value.type, value.state.on, value.state.bri, value.state.colormode == 'xy' ? value.state.xy : null, value.state.ct));
                             }
                             else if (type === 'group') {
-                                objects.push(new Group(instance, key, value.name, value.type, value.state.all_on, value.action.bri, value.action.xy, value.action.ct));
+                                objects.push(new Group(instance, key, value.name, value.type, value.state.all_on, value.action.bri, value.action.colormode == 'xy' ? value.action.xy : null, value.action.ct));
                             }
                             else if (type === 'scene') {
                                 objects.push(new Scene(instance, key, value.name, value.type, value.group));


### PR DESCRIPTION
I think this addresses the suggestion from https://github.com/elgatosf/streamdeck-philipshue/issues/29

I have NOT tested this patch on a group of lights yet and I'm not sure if there are any other ramifications of setting xy = null elsewhere. The StreamDeck UI seems to be ok with the changes and does what I expect, but I haven't tested it very much at this point with real lights.