### PR TITLE
Add 20% Brightness Dial Increment Option

### DIFF
--- a/Sources/com.elgato.philips-hue.sdPlugin/pi/js/brightnessPI.js
+++ b/Sources/com.elgato.philips-hue.sdPlugin/pi/js/brightnessPI.js
@@ -28,7 +28,7 @@ function BrightnessPI(inContext, inLanguage, inStreamDeckVersion, inPluginVersio
 
     };
 
-    const values = [1,2,3,4,5,10];
+    const values = [1,2,3,4,5,10,20];
     const selectedIndex = values.indexOf(Number(settings.scaleTicks));
 
     // Add brightness slider

--- a/Sources/com.elgato.philips-hue.sdPlugin/pi/js/pi.js
+++ b/Sources/com.elgato.philips-hue.sdPlugin/pi/js/pi.js
@@ -9,7 +9,7 @@ function PI(inContext, inLanguage, inStreamDeckVersion, inPluginVersion) {
     // Init PI
     let instance = this;
 
-    const values = [1,2,3,4,5,10];
+    const values = [1,2,3,4,5,10,20];
     this.getEncoderOptions = (settingsValue, forEncoder) => {
       const selectedIndex = values.indexOf(Number(settingsValue));
       return forEncoder === true ? `<div type="select" class="sdpi-item">


### PR DESCRIPTION
**Reasoning / Context:** Because the Philips Hue protocol seems inherently slow, unless you turn the dial very slowly, not every click registers. So you could turn the dial 5-6 clicks at once with a 10% increment, but it will only end up changing the brightness by 20% or so. This means that to change the hue brightness by a significant amount, it requires deliberately slowly turning the dial 1 click at a time and waiting for each change to register before turning it again.

**Change:** A 20% increment option allows a much more significant brightness change with each click. Therefore being able to traverse from bright-to-dark or vice versa quickly with just a couple clicks, even though waiting between each turn is required. While 10% (current max increment) is ok, it doesn't really produce a majorly noticeable change visually, so in my experience I always have to turn the dial at least 2 clicks anyway, so 20% would be much more useful.